### PR TITLE
Removing ./example from package.json and fixing typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ npm install @defvayne23/svg-marker
   The API allows SVGs as icons, but only a single path. I had a use case of a complex image that needed look great at about 50x50 pixels. SVG fits this, but the SVGs required multiple paths and multiple colors. I couldn't find a simple overlay class, so I created my own.
 
 ## License
-MITb
+MIT

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.1",
   "description": "Class to create a marker in Google Maps Javascript API using a SVG file as the icon.",
   "main": "SVGMarker.js",
-  "directories": {
-    "example": "example"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/defvayne23/SVGMarker.git"


### PR DESCRIPTION
:shipit: 
